### PR TITLE
use conf.d if sites-available and sites-enabled don't exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -401,10 +401,21 @@ Do you want to install Certbot with snap? (recommended)"
         fi
 
         # Add Nginx config
-        if [ ! -f "/etc/nginx/sites-available/rustdesk.conf" ]
+        if [ -d "/etc/nginx/sites-available" ] && [ -d "/etc/nginx/sites-enabled" ]
         then
-            touch "/etc/nginx/sites-available/rustdesk.conf"
-            cat << NGINX_RUSTDESK_CONF > "/etc/nginx/sites-available/rustdesk.conf"
+            SITES_CONF_DIR="sites-available"
+        elif [ -d "/etc/nginx/conf.d" ]
+        then
+            SITES_CONF_DIR="conf.d"
+        else
+            msg_box "Couldn't find the Nginx config directory. Please check your system!"
+            exit 1
+        fi
+
+        if [ ! -f "/etc/nginx/$SITES_CONF_DIR/rustdesk.conf" ]
+        then
+            touch "/etc/nginx/$SITES_CONF_DIR/rustdesk.conf"
+            cat << NGINX_RUSTDESK_CONF > "/etc/nginx/$SITES_CONF_DIR/rustdesk.conf"
 server {
   server_name ${RUSTDESK_DOMAIN};
       location / {
@@ -417,7 +428,7 @@ NGINX_RUSTDESK_CONF
         fi
 
         # Enable the Nginx config file
-        if [ ! -f /etc/nginx/sites-enabled/rustdesk.conf ]
+        if [ "$SITES_CONF_DIR" = "sites-available" ] && [ ! -f /etc/nginx/sites-enabled/rustdesk.conf ]
         then
             ln -s /etc/nginx/sites-available/rustdesk.conf /etc/nginx/sites-enabled/rustdesk.conf
         fi

--- a/restore.sh
+++ b/restore.sh
@@ -272,9 +272,18 @@ server {
 }
 EOF
 )"
-echo "${rustdesknginx}" | sudo tee /etc/nginx/sites-available/rustdesk.conf >/dev/null
 
-sudo ln -s /etc/nginx/sites-available/rustdesk.conf /etc/nginx/sites-enabled/rustdesk.conf
+if [ -d "/etc/nginx/sites-available" ] && [ -d "/etc/nginx/sites-enabled" ]
+then
+    echo "${rustdesknginx}" | sudo tee /etc/nginx/sites-available/rustdesk.conf >/dev/null
+    sudo ln -s /etc/nginx/sites-available/rustdesk.conf /etc/nginx/sites-enabled/rustdesk.conf
+elif [ -d "/etc/nginx/conf.d" ]
+then
+    echo "${rustdesknginx}" | sudo tee /etc/nginx/conf.d/rustdesk.conf >/dev/null
+else
+    msg_box "Couldn't find the Nginx config directory. Please check your system!"
+    exit 1
+fi
 
 sudo ufw allow 80/tcp
 sudo ufw allow 443/tcp


### PR DESCRIPTION
If there are no sites-available and sites-enabled directories, use the conf.d directory. Tested on rocky linux 9.0 and ubuntu 22.04.
Some problems:
* `install_linux_package snapd` is not enough on some distributions, https://snapcraft.io/docs/search?q=installing+snap+on
* My problem: requesting certificate Only succeeded once.