### PR TITLE
install.sh: default plain IP

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -358,11 +358,11 @@ done
 choice=$(whiptail --title "Rustdesk installation script" --menu \
 "Choose your preferred option, IP or DNS/Domain:
 
-DNS = Setup Rustdesk with TLS and your own domain
 IP  = You don't have a domain, only plain IP
+DNS = Setup Rustdesk with TLS and your own domain
 $MENU_GUIDE\n\n$RUN_LATER_GUIDE" "$WT_HEIGHT" "$WT_WIDTH" 4 \
-"DNS" "(e.g. rustdesk.example.com)" \
-"IP" "($WANIP4)" 3>&1 1>&2 2>&3)
+"IP" "($WANIP4)" \
+"DNS" "(e.g. rustdesk.example.com)" 3>&1 1>&2 2>&3)
 
 case "$choice" in
     "DNS")


### PR DESCRIPTION
Using the IP address makes the installation simpler. I tested both pressing Enter directly on the interface and selecting the domain option.

### before

<img width="798" height="248" alt="before" src="https://github.com/user-attachments/assets/643bedb5-49c7-4b5f-9998-1147451249ac" />

### after

<img width="824" height="279" alt="after" src="https://github.com/user-attachments/assets/2d5b9f16-68d3-45f1-9c07-7b19508a2efe" />
