### PR TITLE
Create issue/feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Report something that is broken or behaving unexpectedly
+title: "[Bug]: "
+labels:
+  - bug
+  - triage
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the bug
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened
+      placeholder: What did happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, reliable steps to reproduce the issue
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: frequency
+    attributes:
+      label: Frequency
+      description: How often does it happen?
+      placeholder: e.g. always, sometimes, once
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Release version
+      placeholder: e.g. v1.2.3
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, runtime, deployment context, relevant tooling versions
+      placeholder: e.g. macOS 14, Linux, Docker, Go 1\.xx
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots / attachments
+      description: Paste relevant output. Redact secrets.
+      placeholder: Include stack traces, console output, screenshots, etc.
+      render: shell
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact / severity
+      description: Who is affected and how urgent it is
+      placeholder: e.g. blocks deployment, minor annoyance, data loss risk
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: I included enough details to reproduce the bug
+          required: true
+        - label: I removed or redacted secrets (tokens, passwords, private keys)
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,70 @@
+name: Feature request
+description: Suggest an improvement or a new capability
+title: "[Feature]: "
+labels:
+  - enhancement
+  - triage
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the feature
+      placeholder: What do you want to add or change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve or what goal does it enable?
+      placeholder: Why is this needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe how you think this should work
+      placeholder: What should the system do?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why they are not preferred
+      placeholder: Any workarounds or alternative designs?
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What does "done" look like?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+      
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact / priority
+      description: Who benefits and how important this is
+      placeholder: e.g. unblocks workflow, nice\-to\-have, high impact
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: I provided enough detail to evaluate the request
+          required: true
+        - label: This is specifically referring to RustDesk Server Pro
+          required: true
+        - label: I removed or redacted secrets (tokens, passwords, private keys)
+          required: true


### PR DESCRIPTION
This helps enforce a consistent structure and template for issues. Just made a quick semi-generic template that should help create some consistency.

Ironically no, I did not create a PR template 